### PR TITLE
Fix mingw cross compilation on linux

### DIFF
--- a/qtbase/src/corelib/io/qstandardpaths_win.cpp
+++ b/qtbase/src/corelib/io/qstandardpaths_win.cpp
@@ -12,7 +12,7 @@
 
 #include <qt_windows.h>
 #include <shlobj.h>
-#include <VersionHelpers.h>
+#include <versionhelpers.h>
 #include <intshcut.h>
 #include <qvarlengtharray.h>
 

--- a/qtbase/src/gui/rhi/qrhid3d11.cpp
+++ b/qtbase/src/gui/rhi/qrhid3d11.cpp
@@ -12,7 +12,7 @@
 
 #include <cstdio>
 
-#include <VersionHelpers.h>
+#include <versionhelpers.h>
 
 QT_BEGIN_NAMESPACE
 


### PR DESCRIPTION
On Linux when cross compiling for Windows, the headers are lowercase and linux cannot find them if the case is not correct.
Windows is case insensitive so it does not matter.